### PR TITLE
address issue where if no alleles found at all, should return 0 

### DIFF
--- a/stringMLST.py
+++ b/stringMLST.py
@@ -422,6 +422,10 @@ def findST(finalProfile,stProfile):
 	for gene, allele in finalProfile.iteritems():
 		transformedFinalProfile[finalGeneToSTGene[gene]] = allele
 
+        # Check to see if the dictionary is empty, if so then means no allele were found at all
+        if bool(transformedFinalProfile) == False:
+                return 0
+        
 	# Find the best matching ST, considering only the genes in the sample's profile. This is to
 	# allow for superfluous columns in the ST profile.
 	logging.debug("findST")


### PR DESCRIPTION
So if someone submitted a Ecoli genome against listeria MLST, this catch will always return 0

Addresses #7 
